### PR TITLE
Display encounter methods in interactive map

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,14 +10,22 @@ def get_routes():
     routes = cur.fetchall()
     result = []
     for r in routes:
-        cur.execute("SELECT pokemon, rate FROM encounters WHERE route_id = ?", (r[0],))
+        cur.execute(
+            "SELECT pokemon, rate, method FROM encounters WHERE route_id = ?",
+            (r[0],),
+        )
         encounters = cur.fetchall()
-        result.append({
-            'id': r[0],
-            'name': r[1],
-            'completed': bool(r[2]),
-            'pokemon': [{'name': p[0], 'rate': p[1]} for p in encounters]
-        })
+        result.append(
+            {
+                'id': r[0],
+                'name': r[1],
+                'completed': bool(r[2]),
+                'pokemon': [
+                    {'name': p[0], 'rate': p[1], 'method': p[2]}
+                    for p in encounters
+                ],
+            }
+        )
     conn.close()
     return result
 

--- a/app.py
+++ b/app.py
@@ -4,30 +4,29 @@ import sqlite3
 app = Flask(__name__)
 
 def get_routes():
-    conn = sqlite3.connect('data/encounters.db')
-    cur = conn.cursor()
-    cur.execute("SELECT id, name, completed FROM routes")
-    routes = cur.fetchall()
-    result = []
-    for r in routes:
-        cur.execute(
-            "SELECT pokemon, rate, method FROM encounters WHERE route_id = ?",
-            (r[0],),
-        )
-        encounters = cur.fetchall()
-        result.append(
-            {
-                'id': r[0],
-                'name': r[1],
-                'completed': bool(r[2]),
-                'pokemon': [
-                    {'name': p[0], 'rate': p[1], 'method': p[2]}
-                    for p in encounters
-                ],
-            }
-        )
-    conn.close()
-    return result
+    with sqlite3.connect('data/encounters.db') as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT id, name, completed FROM routes")
+        routes = cur.fetchall()
+        result = []
+        for r in routes:
+            cur.execute(
+                "SELECT pokemon, rate, method FROM encounters WHERE route_id = ?",
+                (r[0],),
+            )
+            encounters = cur.fetchall()
+            result.append(
+                {
+                    'id': r[0],
+                    'name': r[1],
+                    'completed': bool(r[2]),
+                    'pokemon': [
+                        {'name': p[0], 'rate': p[1], 'method': p[2]}
+                        for p in encounters
+                    ],
+                }
+            )
+        return result
 
 @app.route('/')
 def index():
@@ -40,11 +39,10 @@ def api_routes():
 @app.route('/api/complete', methods=['POST'])
 def mark_complete():
     route_id = request.json['route_id']
-    conn = sqlite3.connect('data/encounters.db')
-    cur = conn.cursor()
-    cur.execute("UPDATE routes SET completed = 1 WHERE id = ?", (route_id,))
-    conn.commit()
-    conn.close()
+    with sqlite3.connect('data/encounters.db') as conn:
+        cur = conn.cursor()
+        cur.execute("UPDATE routes SET completed = 1 WHERE id = ?", (route_id,))
+        conn.commit()
     return '', 204
 
 if __name__ == '__main__':

--- a/templates/index.html
+++ b/templates/index.html
@@ -101,15 +101,37 @@
           marker.style.top = y + 'px';
           if (route.completed) marker.classList.add('completed');
 
+          const formatMethod = (m) =>
+            m
+              .replace(/-/g, ' ')
+              .replace(/\b\w/g, (c) => c.toUpperCase());
+
           marker.onclick = () => {
             currentRoute = route;
             routeTitle.textContent = route.name;
             pokemonList.innerHTML = '';
-            route.pokemon.forEach(p => {
-              const li = document.createElement('li');
-              li.textContent = `${p.name} - ${p.rate}`;
-              pokemonList.appendChild(li);
+
+            const groups = {};
+            route.pokemon.forEach((p) => {
+              if (!groups[p.method]) groups[p.method] = [];
+              groups[p.method].push(p);
             });
+
+            Object.keys(groups).forEach((method) => {
+              const methodItem = document.createElement('li');
+              methodItem.innerHTML = `<strong>${formatMethod(method)}</strong>`;
+              const subList = document.createElement('ul');
+
+              groups[method].forEach((p) => {
+                const li = document.createElement('li');
+                li.textContent = `${p.name} - ${p.rate}`;
+                subList.appendChild(li);
+              });
+
+              methodItem.appendChild(subList);
+              pokemonList.appendChild(methodItem);
+            });
+
             modal.style.display = 'flex';
           };
 


### PR DESCRIPTION
## Summary
- expose encounter methods in the `/api/routes` endpoint
- group encounters by method in the modal popup

## Testing
- `python -m py_compile app.py`
- `pip install flask` *(to satisfy runtime requirements)*


------
https://chatgpt.com/codex/tasks/task_e_6888c91c414c8324a5d7d8b2e85d42a4