### PR TITLE
Extend database loader for all Pokemon regions

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -4,23 +4,34 @@ import time
 import re
 import os
 
-
-def clean_location_name(name):
-    name = name.replace("kanto-", "").replace("-area", "")
-    name = name.replace("-", " ").title()
-    if "Route" in name:
-        name = re.sub(r"Route (\\d+)", r"Route \\1", name)
-    return name.strip()
-
-
-SUPPORTED_VERSIONS = {"red", "blue", "yellow", "firered", "leafgreen"}
 CHECKPOINT_FILE = "data/checkpoint.txt"
 
-os.makedirs("data", exist_ok=True)
-conn = sqlite3.connect("data/encounters.db")
-cur = conn.cursor()
+REGIONS = {
+    1: "Kanto",
+    2: "Johto",
+    3: "Hoenn",
+    4: "Sinnoh",
+    5: "Unova",
+    6: "Kalos",
+    7: "Alola",
+    8: "Galar",
+    9: "Paldea",
+}
 
-def load_checkpoint():
+VERSIONS_PER_REGION = {
+    "kanto": {"red", "blue", "yellow", "firered", "leafgreen"},
+    "johto": {"gold", "silver", "crystal", "heartgold", "soulsilver"},
+    "hoenn": {"ruby", "sapphire", "emerald", "omegaruby", "alphasapphire"},
+    "sinnoh": {"diamond", "pearl", "platinum", "brilliant-diamond", "shining-pearl"},
+    "unova": {"black", "white", "black-2", "white-2"},
+    "kalos": {"x", "y"},
+    "alola": {"sun", "moon", "ultra-sun", "ultra-moon"},
+    "galar": {"sword", "shield"},
+    "paldea": {"scarlet", "violet"},
+}
+
+
+def load_checkpoint() -> int:
     if os.path.exists(CHECKPOINT_FILE):
         try:
             with open(CHECKPOINT_FILE) as f:
@@ -28,6 +39,21 @@ def load_checkpoint():
         except Exception:
             return 0
     return 0
+
+
+def clean_location_name(name: str) -> str:
+    # remove region prefix and -area suffix then prettify
+    name = re.sub(r"^(kanto|johto|hoenn|sinnoh|unova|kalos|alola|galar|paldea)-", "", name)
+    name = name.replace("-area", "")
+    name = name.replace("-", " ").title()
+    if "Route" in name:
+        name = re.sub(r"Route (\d+)", r"Route \1", name)
+    return name.strip()
+
+
+os.makedirs("data", exist_ok=True)
+conn = sqlite3.connect("data/encounters.db")
+cur = conn.cursor()
 
 start_index = load_checkpoint()
 
@@ -60,73 +86,107 @@ cur.execute(
     pokemon TEXT,
     rate TEXT,
     method TEXT,
+    max_level INTEGER,
     FOREIGN KEY(route_id) REFERENCES routes(id)
 )"""
 )
 
-cur.execute("SELECT id FROM regions WHERE name = 'Kanto'")
-row = cur.fetchone()
-if row:
-    kanto_id = row[0]
-else:
-    cur.execute("INSERT INTO regions (name) VALUES ('Kanto')")
-    kanto_id = cur.lastrowid
-    conn.commit()
+counter = 0
 
-cur.execute("SELECT name FROM routes")
-route_names_seen = {r[0] for r in cur.fetchall()}
+for region_id, region_name in REGIONS.items():
+    cur.execute("SELECT id FROM regions WHERE name = ?", (region_name,))
+    row = cur.fetchone()
+    if row:
+        region_db_id = row[0]
+    else:
+        cur.execute("INSERT INTO regions (name) VALUES (?)", (region_name,))
+        region_db_id = cur.lastrowid
+        conn.commit()
 
-region_data = requests.get("https://pokeapi.co/api/v2/region/1").json()
+    cur.execute("SELECT name FROM routes WHERE region_id = ?", (region_db_id,))
+    route_names_seen = {r[0] for r in cur.fetchall()}
 
-for idx, location in enumerate(region_data["locations"][start_index:], start=start_index):
-    loc_detail = requests.get(location["url"]).json()
-    for area in loc_detail["areas"]:
-        area_data = requests.get(area["url"]).json()
-        name = clean_location_name(area_data["name"])
+    try:
+        region_data = requests.get(f"https://pokeapi.co/api/v2/region/{region_id}").json()
+    except Exception:
+        print(f"Failed to fetch data for {region_name}")
+        continue
 
-        if name in route_names_seen:
+    for location in region_data["locations"]:
+        if counter < start_index:
+            counter += 1
             continue
-        route_names_seen.add(name)
+        try:
+            loc_detail = requests.get(location["url"]).json()
+        except Exception:
+            print(f"Failed to fetch location {location['name']} in {region_name}")
+            continue
+        for area in loc_detail["areas"]:
+            try:
+                area_data = requests.get(area["url"]).json()
+            except Exception:
+                print(f"Failed to fetch area {area['name']} in {region_name}")
+                continue
+            name = clean_location_name(area_data["name"])
 
-        cur.execute(
-            "INSERT INTO routes (name, region_id) VALUES (?, ?)", (name, kanto_id)
-        )
-        route_id = cur.lastrowid
+            if name in route_names_seen:
+                continue
+            route_names_seen.add(name)
 
-        added = False
-        seen = set()
+            cur.execute(
+                "INSERT INTO routes (name, region_id) VALUES (?, ?)",
+                (name, region_db_id),
+            )
+            route_id = cur.lastrowid
 
-        for poke in area_data["pokemon_encounters"]:
-            species = poke["pokemon"]["name"].title()
-            for v in poke["version_details"]:
-                version = v["version"]["name"]
-                if version in SUPPORTED_VERSIONS:
+            added = False
+
+            allowed_versions = VERSIONS_PER_REGION.get(region_name.lower(), set())
+
+            for poke in area_data["pokemon_encounters"]:
+                species = poke["pokemon"]["name"].title()
+                aggregates = {}
+
+                for v in poke["version_details"]:
+                    version = v["version"]["name"]
+                    if allowed_versions and version not in allowed_versions:
+                        continue
                     for d in v["encounter_details"]:
                         chance = d.get("chance")
                         method = d["method"]["name"]
-                        key = (species, chance, method)
-                        if chance and key not in seen:
-                            seen.add(key)
-                            cur.execute(
-                                "INSERT INTO encounters (route_id, pokemon, rate, method) VALUES (?, ?, ?, ?)",
-                                (route_id, species, f"{chance}%", method),
-                            )
-                            added = True  # ✅ Important fix
+                        if not chance:
+                            continue
+                        key = (species, method)
+                        max_level = d.get("max_level", 0)
+                        if key not in aggregates:
+                            aggregates[key] = {"rate": 0, "max_level": 0}
+                        aggregates[key]["rate"] += chance
+                        aggregates[key]["max_level"] = max(
+                            aggregates[key]["max_level"], max_level
+                        )
 
-        if not added:
-            cur.execute("DELETE FROM routes WHERE id = ?", (route_id,))
-            route_names_seen.remove(name)
+                for (spec, method), vals in aggregates.items():
+                    cur.execute(
+                        "INSERT INTO encounters (route_id, pokemon, rate, method, max_level) VALUES (?, ?, ?, ?, ?)",
+                        (route_id, spec, f"{vals['rate']}%", method, vals["max_level"]),
+                    )
+                    added = True
 
-        print(f"Processed: {name}")
-        time.sleep(0.5)
+            if not added:
+                cur.execute("DELETE FROM routes WHERE id = ?", (route_id,))
+                route_names_seen.remove(name)
 
-    with open(CHECKPOINT_FILE, "w") as f:
-        f.write(str(idx + 1))
+
+            print(f"Processed {region_name}: {name}")
+            time.sleep(0.5)
+
+        with open(CHECKPOINT_FILE, "w") as f:
+            f.write(str(counter + 1))
+        conn.commit()
+        counter += 1
+
     conn.commit()
 
-if os.path.exists(CHECKPOINT_FILE):
-    os.remove(CHECKPOINT_FILE)
-
-conn.commit()
 conn.close()
-print("✅ Kanto encounter data loaded into data/encounters.db")
+print("✅ Encounter data loaded into data/encounters.db")
+


### PR DESCRIPTION
## Summary
- overhaul `create_db.py` to import encounters for every region
- include regional version filters and generalised location cleanup
- restore checkpoint support for long data pulls
- track the highest max level for each encounter
- combine encounter rates per method when inserting data

## Testing
- `python3 -m py_compile create_db.py`
- `python create_db.py` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6888e28f50ac8324b5df9da41cf35a73